### PR TITLE
fix compiler warnings on Xcode 12

### DIFF
--- a/fliclib.xcframework/ios-armv7_arm64/fliclib.framework/Headers/SCLFlicManager.h
+++ b/fliclib.xcframework/ios-armv7_arm64/fliclib.framework/Headers/SCLFlicManager.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreBluetooth/CoreBluetooth.h>
-#import "SCLFlicButton.h"
+#import <fliclib/SCLFlicButton.h>
 
 /*!
  *  @enum SCLFlicManagerBluetoothState

--- a/fliclib.xcframework/ios-x86_64_i386-simulator/fliclib.framework/Headers/SCLFlicManager.h
+++ b/fliclib.xcframework/ios-x86_64_i386-simulator/fliclib.framework/Headers/SCLFlicManager.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreBluetooth/CoreBluetooth.h>
-#import "SCLFlicButton.h"
+#import <fliclib/SCLFlicButton.h>
 
 /*!
  *  @enum SCLFlicManagerBluetoothState


### PR DESCRIPTION
fix compiler warnings because CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES in Xcode 12